### PR TITLE
Fix syntax error in Podfile

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -93,3 +93,4 @@ post_install do |installer|
                 end
         end
     end
+end


### PR DESCRIPTION
Hello, @sergdort 
This repository is very helpful for learning modern swift app architecture.
I noticed that `pod install` failed because of a syntax error in `Podfile`, so I fixed it ;)