### PR TITLE
Rename type to use more general Domain type

### DIFF
--- a/CleanArchitectureRxSwift/Application/Application.swift
+++ b/CleanArchitectureRxSwift/Application/Application.swift
@@ -9,7 +9,7 @@ final class Application {
 
     private let coreDataUseCaseProvider: Domain.UseCaseProvider
     private let realmUseCaseProvider: Domain.UseCaseProvider
-    private let networkUseCaseProvider: NetworkPlatform.UseCaseProvider
+    private let networkUseCaseProvider: Domain.UseCaseProvider
 
     private init() {
         self.coreDataUseCaseProvider = CoreDataPlatform.UseCaseProvider()


### PR DESCRIPTION
All of the use case providers in Application should have the more general requirement of conforming to Domain.UseCaseProvider rather than be a specific concrete type.